### PR TITLE
Add GET endpoints for ValueSet data

### DIFF
--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -173,7 +173,7 @@ func (app *application) getCodeSystemConceptByID(w http.ResponseWriter, r *http.
 }
 
 func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) {
-	codeSystems, err := models.GetAllValueSets(r.Context(), app.db)
+	valueSets, err := models.GetAllValueSets(r.Context(), app.db)
 	if err != nil {
 		if errors.Is(err, models.ErrDoesNotExist) {
 			http.NotFound(w, r)
@@ -185,7 +185,7 @@ func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) 
 
 	w.Header().Set("Content-Type", "application/json")
 
-	json.NewEncoder(w).Encode(codeSystems)
+	json.NewEncoder(w).Encode(valueSets)
 }
 
 // getValueSetByOid can handle either an ID or an OID; see helper method DetermineIdType in models/db.xo.go

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -169,4 +170,22 @@ func (app *application) getCodeSystemConceptByID(w http.ResponseWriter, r *http.
 	w.Header().Set("Content-Type", "application/json")
 
 	json.NewEncoder(w).Encode(codeSystemConcept)
+}
+
+func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+
+	codeSystems, err := models.GetAllValueSets(ctx, app.db)
+	if err != nil {
+		if errors.Is(err, models.ErrDoesNotExist) {
+			http.NotFound(w, r)
+		} else {
+			app.serverError(w, r, err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(codeSystems)
 }

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -173,9 +173,7 @@ func (app *application) getCodeSystemConceptByID(w http.ResponseWriter, r *http.
 }
 
 func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
-
-	codeSystems, err := models.GetAllValueSets(ctx, app.db)
+	codeSystems, err := models.GetAllValueSets(r.Context(), app.db)
 	if err != nil {
 		if errors.Is(err, models.ErrDoesNotExist) {
 			http.NotFound(w, r)
@@ -192,10 +190,8 @@ func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) 
 
 // getValueSetByOid can handle either an ID or an OID; see helper method DetermineIdType in models/db.xo.go
 func (app *application) getValueSetByOID(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
-
 	id := r.PathValue("oid")
-	valueSet, err := models.ValueSetByOid(ctx, app.db, id)
+	valueSet, err := models.ValueSetByOid(r.Context(), app.db, id)
 
 	if err != nil {
 		if errors.Is(err, models.ErrDoesNotExist) {

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -76,7 +76,7 @@ func (app *application) getViewByID(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, models.ErrDoesNotExist) {
 			http.NotFound(w, r)
 		} else if errors.Is(err, sql.ErrNoRows) {
-			errorString := fmt.Sprintf("Error: View not found", id)
+			errorString := fmt.Sprintf("Error: View %s not found", id)
 			http.Error(w, errorString, http.StatusNotFound)
 		} else {
 			app.serverError(w, r, err)

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -188,7 +188,7 @@ func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(valueSets)
 }
 
-// getValueSetByOid can handle either an ID or an OID; see helper method DetermineIdType in models/db.xo.go
+// getValueSetByOid can retrieve a resource via either ID or an OID (see models.valueset.xo.go)
 func (app *application) getValueSetByOID(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("oid")
 	valueSet, err := models.ValueSetByOid(r.Context(), app.db, id)

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -188,7 +188,7 @@ func (app *application) getAllValueSets(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(valueSets)
 }
 
-// getValueSetByOid can retrieve a resource via either ID or an OID (see models.valueset.xo.go)
+// getValueSetByOid can retrieve a resource via either ID or an OID (see models/valueset.xo.go)
 func (app *application) getValueSetByOID(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("oid")
 	valueSet, err := models.ValueSetByOid(r.Context(), app.db, id)

--- a/cmd/web/helpers.go
+++ b/cmd/web/helpers.go
@@ -15,6 +15,16 @@ func (app *application) serverError(w http.ResponseWriter, r *http.Request, err 
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }
 
+func (app *application) badRequest(w http.ResponseWriter, r *http.Request, err error) {
+	var (
+		method = r.Method
+		uri    = r.URL.RequestURI()
+	)
+
+	app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+	http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+}
+
 // func (app *application) clientError(w http.ResponseWriter, status int) {
 // 	http.Error(w, http.StatusText(status), status)
 // }

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -17,6 +17,7 @@ func (app *application) routes() http.Handler {
 	mux.HandleFunc("GET /api/code-system-concepts", app.getAllCodeSystemConcepts)
 	mux.HandleFunc("GET /api/code-system-concepts/{id}", app.getCodeSystemConceptByID)
 	mux.HandleFunc("GET /api/value-sets", app.getAllValueSets)
+	mux.HandleFunc("GET /api/value-sets/{oid}", app.getValueSetByOID)
 
 	mux.HandleFunc("GET /api/views", app.getAllViews)
 	mux.HandleFunc("GET /api/views/{id}", app.getViewByID)

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -16,6 +16,7 @@ func (app *application) routes() http.Handler {
 	mux.HandleFunc("GET /api/code-systems/{oid}", app.getCodeSystemByOID)
 	mux.HandleFunc("GET /api/code-system-concepts", app.getAllCodeSystemConcepts)
 	mux.HandleFunc("GET /api/code-system-concepts/{id}", app.getCodeSystemConceptByID)
+	mux.HandleFunc("GET /api/value-sets", app.getAllValueSets)
 
 	mux.HandleFunc("GET /api/views", app.getAllViews)
 	mux.HandleFunc("GET /api/views/{id}", app.getViewByID)

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,15 @@ module github.com/skylight-hq/phinvads-go
 
 go 1.22.5
 
-require github.com/jackc/pgx/v5 v5.6.0
+require (
+	github.com/jackc/pgx/v5 v5.6.0
+	github.com/justinas/alice v1.2.0
+)
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
-	github.com/justinas/alice v1.2.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/models/db.xo.go
+++ b/internal/models/db.xo.go
@@ -95,6 +95,8 @@ const (
 	ErrMarkedForDeletion Error = "marked for deletion"
 )
 
+var ErrBadRequest = fmt.Errorf("unrecognized identifier")
+
 // ErrInsertFailed is the insert failed error.
 type ErrInsertFailed struct {
 	Err error

--- a/internal/models/valueset.xo.go
+++ b/internal/models/valueset.xo.go
@@ -137,7 +137,7 @@ func (vs *ValueSet) Delete(ctx context.Context, db DB) error {
 // Generated from index 'value_set_pkey'.
 func ValueSetByOid(ctx context.Context, db DB, oid string) (*ValueSet, error) {
 	// query
-	const sqlstr = `SELECT ` + 
+	const sqlstr = `SELECT ` +
 		`oid, id, name, code, status, definitiontext, scopenotetext, assigningauthorityid, legacyflag, statusdate ` +
 		`FROM public.value_set ` +
 		`WHERE id = $1 OR oid = $1`

--- a/internal/models/valueset.xo.go
+++ b/internal/models/valueset.xo.go
@@ -5,8 +5,6 @@ package models
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"regexp"
 	"time"
 )
 
@@ -140,16 +138,12 @@ func (vs *ValueSet) Delete(ctx context.Context, db DB) error {
 //
 // ValueSetByOid
 func ValueSetByOid(ctx context.Context, db DB, oid string) (*ValueSet, error) {
-	fmt.Println("kcd", oid)
-	dbId, err := DetermineIdType(oid)
-	if err != nil {
-		return nil, logerror(err)
-	}
 	// query
-	var sqlstr = `SELECT ` + 
+	var sqlstr = (`SELECT ` + 
 		`oid, id, name, code, status, definitiontext, scopenotetext, assigningauthorityid, legacyflag, statusdate ` +
 		`FROM public.value_set ` +
-		`WHERE ` + dbId + ` = $1`
+		`WHERE id = $1 OR oid = $1`)
+
 	// run
 	logf(sqlstr, oid)
 	vs := ValueSet{
@@ -180,19 +174,4 @@ func GetAllValueSets(ctx context.Context, db DB) (*[]ValueSet, error) {
 		valueSets = append(valueSets, vs)
 	}
 	return &valueSets, nil
-}
-
-// DetermineIdType returns either "id", "oid", or an error, depending on the regex match
-func DetermineIdType(input string) (idType string, err error) {
-	validId, _ := regexp.MatchString("^[a-zA-Z0-9-]+$", input)
-	validOid, _ := regexp.MatchString("^[0-9.]+$",input)
-	
-	fmt.Println(validId, validOid)
-	if validId {
-		return "id", nil
-	} else if validOid {
-		return "oid", nil
-	} else {
-		return "", ErrBadRequest
-	}
 }

--- a/internal/models/valueset.xo.go
+++ b/internal/models/valueset.xo.go
@@ -139,7 +139,7 @@ func (vs *ValueSet) Delete(ctx context.Context, db DB) error {
 // ValueSetByOid
 func ValueSetByOid(ctx context.Context, db DB, oid string) (*ValueSet, error) {
 	// query
-	var sqlstr = (`SELECT ` + 
+	const sqlstr = (`SELECT ` + 
 		`oid, id, name, code, status, definitiontext, scopenotetext, assigningauthorityid, legacyflag, statusdate ` +
 		`FROM public.value_set ` +
 		`WHERE id = $1 OR oid = $1`)

--- a/internal/models/valueset.xo.go
+++ b/internal/models/valueset.xo.go
@@ -135,14 +135,12 @@ func (vs *ValueSet) Delete(ctx context.Context, db DB) error {
 // ValueSetByOid retrieves a row from 'public.value_set' as a [ValueSet].
 //
 // Generated from index 'value_set_pkey'.
-//
-// ValueSetByOid
 func ValueSetByOid(ctx context.Context, db DB, oid string) (*ValueSet, error) {
 	// query
-	const sqlstr = (`SELECT ` + 
+	const sqlstr = `SELECT ` + 
 		`oid, id, name, code, status, definitiontext, scopenotetext, assigningauthorityid, legacyflag, statusdate ` +
 		`FROM public.value_set ` +
-		`WHERE id = $1 OR oid = $1`)
+		`WHERE id = $1 OR oid = $1`
 
 	// run
 	logf(sqlstr, oid)

--- a/internal/models/valueset.xo.go
+++ b/internal/models/valueset.xo.go
@@ -172,3 +172,24 @@ func ValueSetByOid(ctx context.Context, db DB, oid string) (*ValueSet, error) {
 	}
 	return &vs, nil
 }
+// All retrieves all rows from 'public.value_set'
+func GetAllValueSets(ctx context.Context, db DB) (*[]ValueSet, error) {
+	const sqlstr = `SELECT * FROM public.value_set`
+	logf(sqlstr)
+	valueSets := []ValueSet{}
+	rows, err := db.QueryContext(ctx, sqlstr)
+	if err != nil {
+		return nil, logerror(err)
+	}
+	for rows.Next() {
+		vs := ValueSet{
+			_exists: true,
+		}
+		err := rows.Scan(&vs.Oid, &vs.ID, &vs.Name, &vs.Code, &vs.Status, &vs.Definitiontext, &vs.Scopenotetext, &vs.Assigningauthorityid, &vs.Legacyflag, &vs.Statusdate)
+		if err != nil {
+			return nil, logerror(err)
+		}
+		valueSets = append(valueSets, vs)
+	}
+	return &valueSets, nil
+}


### PR DESCRIPTION
Resolves https://github.com/skylight-hq/phinvads-go/issues/2

Add the following endpoints:

GET http://localhost:4000/api/value-sets
GET http://localhost:4000/api/value-sets/{oid}
 - Also added a helper method so that both ID and OID are acceptable at this endpoint

I think there's probably a better way to handle the id/oid input and associated regex and errors, very open to feedback on this one!