### PR TITLE
Add GET endpoints for Value Set Versions

### DIFF
--- a/docs/examples.http
+++ b/docs/examples.http
@@ -1,29 +1,44 @@
-GET http://localhost:4000/api/code-systems
+GET https://localhost:4000/api/code-systems
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/code-systems/2.16.840.1.113883.12.78
+GET https://localhost:4000/api/code-systems/2.16.840.1.113883.12.78
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/views
+GET https://localhost:4000/api/views
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/views/75CCFC2D-47AF-DD11-A7F5-00188B398520
+GET https://localhost:4000/api/views/75CCFC2D-47AF-DD11-A7F5-00188B398520
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/view-versions-by-view/75CCFC2D-47AF-DD11-A7F5-00188B398520
+GET https://localhost:4000/api/view-versions-by-view/75CCFC2D-47AF-DD11-A7F5-00188B398520
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/view-versions/00CBA20C-E51F-DF11-B334-0015173D1785
+GET https://localhost:4000/api/view-versions/00CBA20C-E51F-DF11-B334-0015173D1785
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-sets
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-sets/2.16.840.1.114222.4.11.4151
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-sets/2.16.840.1.114222.4.11.4151/versions
 accept: application/json
 
 ###

--- a/docs/examples.http
+++ b/docs/examples.http
@@ -42,3 +42,8 @@ GET https://localhost:4000/api/value-sets/2.16.840.1.114222.4.11.4151/versions
 accept: application/json
 
 ###
+
+GET https://localhost:4000/api/value-set-versions/54B04798-55CC-E911-8180-005056ABE2F0
+accept: application/json
+
+###

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -255,3 +255,67 @@ func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) 
 
 	json.NewEncoder(w).Encode(valueSet)
 }
+
+func (app *Application) getValueSetVersionsByValueSetOID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+
+	oid := r.PathValue("oid")
+
+	valueSetVersions, err := rp.GetValueSetVersionByValueSetOID(r.Context(), oid)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: Value Set Versions with Value Set OID %s not found", oid)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetVersionsByValueSetOID",
+				Id:     oid,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetVersions)
+}
+
+func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+
+	id := r.PathValue("id")
+
+	valueSetVersion, err := rp.GetValueSetVersionByID(r.Context(), id)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: Value Set Version %s not found", id)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetVersionsByValueSetOID",
+				Id:     id,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetVersion)
+}

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -20,6 +20,9 @@ func (app *Application) routes() http.Handler {
 
 	mux.HandleFunc("GET /api/value-sets", app.getAllValueSets)
 	mux.HandleFunc("GET /api/value-sets/{id}", app.getValueSetByID)
+	mux.HandleFunc("GET /api/value-sets/{oid}/versions", app.getValueSetVersionsByValueSetOID)
+
+	mux.HandleFunc("GET /api/value-set-versions/{id}", app.getValueSetVersionByID)
 
 	mux.HandleFunc("GET /api/views", app.getAllViews)
 	mux.HandleFunc("GET /api/views/{id}", app.getViewByID)


### PR DESCRIPTION
Resolves #4 

Adds GET endpoints for value set versions by value set OID and value set version by ID.

I made a judgement call and decided to skip adding "Groups" endpoints for now since it seems they are unused in PV atm.

<img width="1700" alt="Screenshot 2024-08-12 at 3 56 31 PM" src="https://github.com/user-attachments/assets/e8141ac8-e2d4-4f0c-aa84-159f02549f79">

