### PR TITLE
Add GET endpoints for Value Set Concepts

### DIFF
--- a/docs/examples.http
+++ b/docs/examples.http
@@ -47,3 +47,18 @@ GET https://localhost:4000/api/value-set-versions/54B04798-55CC-E911-8180-005056
 accept: application/json
 
 ###
+
+GET https://localhost:4000/api/value-set-concepts/4C074C07-FEA4-DD11-BB1F-00188B398520
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-set-concepts/value-set-version/B7D34BBC-617F-DD11-B38D-00188B398520
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-set-concepts/code-system/1.0.3166.1
+accept: application/json
+
+###

--- a/docs/examples.http
+++ b/docs/examples.http
@@ -1,29 +1,44 @@
-GET http://localhost:4000/api/code-systems
+GET https://localhost:4000/api/code-systems
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/code-systems/2.16.840.1.113883.12.78
+GET https://localhost:4000/api/code-systems/2.16.840.1.113883.12.78
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/views
+GET https://localhost:4000/api/views
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/views/75CCFC2D-47AF-DD11-A7F5-00188B398520
+GET https://localhost:4000/api/views/75CCFC2D-47AF-DD11-A7F5-00188B398520
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/view-versions-by-view/75CCFC2D-47AF-DD11-A7F5-00188B398520
+GET https://localhost:4000/api/view-versions-by-view/75CCFC2D-47AF-DD11-A7F5-00188B398520
 accept: application/json
 
 ###
 
-GET http://localhost:4000/api/view-versions/00CBA20C-E51F-DF11-B334-0015173D1785
+GET https://localhost:4000/api/view-versions/00CBA20C-E51F-DF11-B334-0015173D1785
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-sets
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-sets/2.16.840.1.114222.4.11.4151
+accept: application/json
+
+###
+
+GET https://localhost:4000/api/value-sets/2.16.840.1.114222.4.11.4151/versions
 accept: application/json
 
 ###

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -319,3 +319,97 @@ func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Re
 
 	json.NewEncoder(w).Encode(valueSetVersion)
 }
+
+func (app *Application) getValueSetConceptByID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+	id := r.PathValue("id")
+
+	valueSetConcept, err := rp.GetValueSetConceptByID(r.Context(), id)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: Value Set Concept %s not found", id)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetConceptByID",
+				Id:     id,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetConcept)
+}
+
+func (app *Application) getValueSetConceptsByVersionID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+	id := r.PathValue("valueSetVersionId")
+
+	valueSetConcepts, err := rp.GetValueSetConceptByValueSetVersionID(r.Context(), id)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: No Value Set Concepts found for version %s", id)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetConceptsByVersionID",
+				Id:     id,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetConcepts)
+}
+
+func (app *Application) getValueSetConceptsByCodeSystemOID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+	oid := r.PathValue("codeSystemOid")
+
+	valueSetConcepts, err := rp.GetValueSetConceptsByCodeSystemOID(r.Context(), oid)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: No Value Set Concepts found for CodeSystem %s", oid)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetConceptsByCodeSystemOID",
+				Id:     oid,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetConcepts)
+}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -255,3 +255,67 @@ func (app *Application) getValueSetByID(w http.ResponseWriter, r *http.Request) 
 
 	json.NewEncoder(w).Encode(valueSet)
 }
+
+func (app *Application) getValueSetVersionsByValueSetOID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+
+	oid := r.PathValue("oid")
+
+	valueSetVersions, err := rp.GetValueSetVersionByValueSetOID(r.Context(), oid)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: Value Set Versions with Value Set OID %s not found", oid)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetVersionsByValueSetOID",
+				Id:     oid,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetVersions)
+}
+
+func (app *Application) getValueSetVersionByID(w http.ResponseWriter, r *http.Request) {
+	rp := app.repository
+
+	id := r.PathValue("id")
+
+	valueSetVersion, err := rp.GetValueSetVersionByID(r.Context(), id)
+	if err != nil {
+		var (
+			method = r.Method
+			uri    = r.URL.RequestURI()
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			errorString := fmt.Sprintf("Error: Value Set Version %s not found", id)
+			dbErr := &customErrors.DatabaseError{
+				Err:    err,
+				Msg:    errorString,
+				Method: "getValueSetVersionsByValueSetOID",
+				Id:     id,
+			}
+			dbErr.NoRows(w, r, err, app.logger)
+		} else {
+			customErrors.ServerError(w, r, err, app.logger)
+		}
+		app.logger.Error(err.Error(), slog.String("method", method), slog.String("uri", uri))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(valueSetVersion)
+}

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -20,6 +20,9 @@ func (app *Application) routes() http.Handler {
 
 	mux.HandleFunc("GET /api/value-sets", app.getAllValueSets)
 	mux.HandleFunc("GET /api/value-sets/{id}", app.getValueSetByID)
+	mux.HandleFunc("GET /api/value-sets/{oid}/versions", app.getValueSetVersionsByValueSetOID)
+
+	mux.HandleFunc("GET /api/value-set-versions/{id}", app.getValueSetVersionByID)
 
 	mux.HandleFunc("GET /api/views", app.getAllViews)
 	mux.HandleFunc("GET /api/views/{id}", app.getViewByID)

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -30,6 +30,10 @@ func (app *Application) routes() http.Handler {
 	mux.HandleFunc("GET /api/view-versions/{id}", app.getViewVersionByID)
 	mux.HandleFunc("GET /api/view-versions-by-view/{viewId}", app.getViewVersionsByViewID)
 
+	mux.HandleFunc("GET /api/value-set-concepts/{id}", app.getValueSetConceptByID)
+	mux.HandleFunc("GET /api/value-set-concepts/value-set-version/{valueSetVersionId}", app.getValueSetConceptsByVersionID)
+	mux.HandleFunc("GET /api/value-set-concepts/code-system/{codeSystemOid}", app.getValueSetConceptsByCodeSystemOID)
+
 	standard := alice.New(app.recoverPanic, app.logRequest, commonHeaders)
 
 	return standard.Then(mux)

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -111,7 +111,11 @@ func (r *Repository) GetViewVersionByVvsvVvId(ctx context.Context, vvsv *xo.View
 // === ValueSetConcept methods === //
 // =============================== //
 func (r *Repository) GetValueSetConceptsByCodeSystemOID(ctx context.Context, csOid string) ([]*xo.ValueSetConcept, error) {
-	return xo.ValueSetConceptByCodesystemoid(ctx, r.database, csOid)
+	result, err := xo.ValueSetConceptByCodesystemoid(ctx, r.database, csOid)
+	if len(result) == 0 {
+		err = sql.ErrNoRows
+	}
+	return result, err
 }
 
 func (r *Repository) GetValueSetConceptByID(ctx context.Context, id string) (*xo.ValueSetConcept, error) {
@@ -119,7 +123,11 @@ func (r *Repository) GetValueSetConceptByID(ctx context.Context, id string) (*xo
 }
 
 func (r *Repository) GetValueSetConceptByValueSetVersionID(ctx context.Context, vsvId string) ([]*xo.ValueSetConcept, error) {
-	return xo.ValueSetConceptByValuesetversionid(ctx, r.database, vsvId)
+	result, err := xo.ValueSetConceptByValuesetversionid(ctx, r.database, vsvId)
+	if len(result) == 0 {
+		err = sql.ErrNoRows
+	}
+	return result, err
 }
 
 // =============================== //

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -44,7 +44,11 @@ func (r *Repository) GetCodeSystemConceptByID(ctx context.Context, id string) (*
 }
 
 func (r *Repository) GetCodeSystemConceptsByOID(ctx context.Context, oid string) ([]*xo.CodeSystemConcept, error) {
-	return xo.CodeSystemConceptByCodesystemoid(ctx, r.database, oid)
+	result, err := xo.CodeSystemConceptByCodesystemoid(ctx, r.database, oid)
+	if len(result) == 0 {
+		err = sql.ErrNoRows
+	}
+	return result, err
 }
 
 func (r *Repository) GetCodeSystemByValueSetConceptCsOid(ctx context.Context, vsc *xo.ValueSetConcept) (*xo.CodeSystem, error) {
@@ -100,7 +104,11 @@ func (r *Repository) GetViewVersionByID(ctx context.Context, id string) (*xo.Vie
 }
 
 func (r *Repository) GetViewVersionByViewId(ctx context.Context, viewId string) ([]*xo.ViewVersion, error) {
-	return xo.ViewVersionByViewid(ctx, r.database, viewId)
+	result, err := xo.ViewVersionByViewid(ctx, r.database, viewId)
+	if len(result) == 0 {
+		err = sql.ErrNoRows
+	}
+	return result, err
 }
 
 func (r *Repository) GetViewVersionByVvsvVvId(ctx context.Context, vvsv *xo.ViewValueSetVersion) (*xo.ViewVersion, error) {
@@ -146,7 +154,11 @@ func (r *Repository) GetValueSetVersionByID(ctx context.Context, id string) (*xo
 }
 
 func (r *Repository) GetValueSetVersionByValueSetOID(ctx context.Context, oid string) ([]*xo.ValueSetVersion, error) {
-	return xo.ValueSetVersionByValuesetoid(ctx, r.database, oid)
+	result, err := xo.ValueSetVersionByValuesetoid(ctx, r.database, oid)
+	if len(result) == 0 {
+		err = sql.ErrNoRows
+	}
+	return result, err
 }
 
 func (r *Repository) GetValueSetVersionByVscVsvId(ctx context.Context, vsc *xo.ValueSetConcept) (*xo.ValueSetVersion, error) {


### PR DESCRIPTION
Resolves https://github.com/skylight-hq/phinvads-go/issues/5

Adds GET endpoints for 
- value set concepts by ID
- value set concepts by value set version ID
- value set concepts by code system OID

Updates repository methods that return a slice of data:
- `sql.ErrNoRows` is not triggered from `db.QueryContext()`, which is what xo uses for multi-row results. To avoid modifying the xo files, we now check in the `Repository` methods whether the length of the returned slice is 0, and if so, return the `noRows` error