### PR TITLE
Dynamically render search results for CodeSystem by OID

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -472,6 +472,7 @@ func (app *Application) formSearch(w http.ResponseWriter, r *http.Request) {
 
 func search(w http.ResponseWriter, r *http.Request, rp *repository.Repository, searchTerm, searchType string, logger *slog.Logger) {
 	var result = &models.CodeSystemResultRow{}
+	defaultPageCount := 5
 
 	// retrieve code system
 	codeSystem, err := rp.GetCodeSystemsByLikeOID(r.Context(), searchTerm)
@@ -486,6 +487,12 @@ func search(w http.ResponseWriter, r *http.Request, rp *repository.Repository, s
 	for _, cs := range *codeSystem {
 		result.CodeSystems = append(result.CodeSystems, &cs)
 	}
+
+	if len(result.CodeSystems) <= defaultPageCount {
+		defaultPageCount = len(result.CodeSystems)
+	}
+
+	result.PageCount = defaultPageCount
 	result.CodeSystemsCount = strconv.Itoa(len(result.CodeSystems))
 
 	// // retrieve concepts that are part of that code system

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -505,7 +505,7 @@ func (app *Application) search(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("HX-Push-Url", fmt.Sprintf("/search?type=%s&input=%s", searchType, input))
 
-	component := components.SearchResults("Search", input, result)
+	component := components.SearchResults(false, "Search", input, result)
 	component.Render(r.Context(), w)
 }
 
@@ -545,7 +545,7 @@ func (app *Application) directSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	component := components.SearchResults("Search", searchTerm, result)
+	component := components.SearchResults(true, "Search", searchTerm, result)
 	component.Render(r.Context(), w)
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -507,14 +507,22 @@ func (app *Application) directSearch(w http.ResponseWriter, r *http.Request) {
 	rp := app.repository
 
 	// retrieve code system
-	codeSystem, _ := rp.GetCodeSystemByOID(r.Context(), searchTerm)
-	result.CodeSystems = append(result.CodeSystems, codeSystem)
+	codeSystem, err := rp.GetCodeSystemsByLikeOID(r.Context(), searchTerm)
+	fmt.Println(err)
+	for _, cs := range *codeSystem {
+		result.CodeSystems = append(result.CodeSystems, &cs)
+	}
 	result.CodeSystemsCount = strconv.Itoa(len(result.CodeSystems))
 
-	// retrieve concepts that are part of that code system
-	concepts, err := rp.GetCodeSystemConceptsByCodeSystemOID(r.Context(), app.db, codeSystem)
-	result.CodeSystemConcepts = concepts
-	result.CodeSystemConceptsCount = strconv.Itoa(len(concepts))
+	// // retrieve concepts that are part of that code system
+	// concepts, err := rp.GetCodeSystemConceptsByCodeSystemOID(r.Context(), app.db, codeSystem)
+	// for _, csc := range *concepts {
+	// 	result.CodeSystems = append(result.CodeSystems, &csc)
+	// }
+	// result.CodeSystemConcepts = concepts
+
+	// for now
+	result.CodeSystemConceptsCount = strconv.Itoa(0)
 
 	// for now
 	result.ValueSetsCount = strconv.Itoa(0)

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -44,7 +44,7 @@ func (app *Application) routes() http.Handler {
 	mux.HandleFunc("GET /toggle-banner/{action}", app.handleBannerToggle)
 	mux.HandleFunc("GET /load-hot-topics", app.getAllHotTopics)
 
-	mux.HandleFunc("POST /api/search", app.search)
+	mux.HandleFunc("POST /api/search", app.formSearch)
 	mux.HandleFunc("GET /search", app.directSearch)
 
 	standard := alice.New(app.recoverPanic, app.logRequest, commonHeaders)

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -44,7 +44,9 @@ func (app *Application) routes() http.Handler {
 	mux.HandleFunc("GET /toggle-banner/{action}", app.handleBannerToggle)
 	mux.HandleFunc("GET /load-hot-topics", app.getAllHotTopics)
 
-	mux.HandleFunc("GET /search-results", app.searchResults)
+	mux.HandleFunc("POST /api/search", app.search)
+	mux.HandleFunc("GET /search", app.directSearch)
+
 	standard := alice.New(app.recoverPanic, app.logRequest, commonHeaders)
 
 	return standard.Then(mux)

--- a/internal/database/models/codesystem.go
+++ b/internal/database/models/codesystem.go
@@ -25,6 +25,26 @@ func GetAllCodeSystems(ctx context.Context, db xo.DB) (*[]xo.CodeSystem, error) 
 	return &codeSystems, nil
 }
 
+func GetCodeSystemByLikeOID(ctx context.Context, db xo.DB, oid string) (*[]xo.CodeSystem, error) {
+	wildcard := oid + "%"
+	const sqlstr = "SELECT * FROM public.code_system WHERE oid LIKE $1"
+
+	codeSystems := []xo.CodeSystem{}
+	rows, err := db.QueryContext(ctx, sqlstr, wildcard)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		cs := xo.CodeSystem{}
+		err := rows.Scan(&cs.Oid, &cs.ID, &cs.Name, &cs.Definitiontext, &cs.Status, &cs.Version, &cs.Versiondescription, &cs.Assigningauthorityversionname, &cs.Distributionsourceversionname, &cs.Distributionsourceid, &cs.Assigningauthorityid, &cs.Codesystemcode, &cs.Sourceurl, &cs.Hl70396identifier, &cs.Legacyflag, &cs.Statusdate, &cs.Acquireddate, &cs.Effectivedate, &cs.Expirydate, &cs.Assigningauthorityreleasedate, &cs.Distributionsourcereleasedate, &cs.Sdocreatedate, &cs.Lastrevisiondate)
+		if err != nil {
+			return nil, err
+		}
+		codeSystems = append(codeSystems, cs)
+	}
+	return &codeSystems, nil
+}
+
 type CodeSystemResultRow struct {
 	CodeSystemsCount        string
 	CodeSystemConceptsCount string

--- a/internal/database/models/codesystem.go
+++ b/internal/database/models/codesystem.go
@@ -24,3 +24,13 @@ func GetAllCodeSystems(ctx context.Context, db xo.DB) (*[]xo.CodeSystem, error) 
 	}
 	return &codeSystems, nil
 }
+
+type CodeSystemResultRow struct {
+	CodeSystemsCount        string
+	CodeSystemConceptsCount string
+	ValueSetsCount          string
+	CodeSystems             []*xo.CodeSystem
+	CodeSystemConcepts      []*xo.CodeSystemConcept
+	ValueSets               []*xo.ValueSet
+	URL                     string
+}

--- a/internal/database/models/codesystem.go
+++ b/internal/database/models/codesystem.go
@@ -53,4 +53,5 @@ type CodeSystemResultRow struct {
 	CodeSystemConcepts      []*xo.CodeSystemConcept
 	ValueSets               []*xo.ValueSet
 	URL                     string
+	PageCount               int
 }

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -32,6 +32,10 @@ func (r *Repository) GetCodeSystemByOID(ctx context.Context, oid string) (*xo.Co
 	return xo.CodeSystemByOid(ctx, r.database, oid)
 }
 
+func (r *Repository) GetCodeSystemsByLikeOID(ctx context.Context, oid string) (*[]xo.CodeSystem, error) {
+	return models.GetCodeSystemByLikeOID(ctx, r.database, oid)
+}
+
 // =============================== //
 // == CodeSystemConcept methods == //
 // =============================== //

--- a/internal/database/models/repository/repository.go
+++ b/internal/database/models/repository/repository.go
@@ -51,6 +51,10 @@ func (r *Repository) GetCodeSystemConceptsByOID(ctx context.Context, oid string)
 	return result, err
 }
 
+func (r *Repository) GetCodeSystemConceptsByCodeSystemOID(ctx context.Context, db xo.DB, cs *xo.CodeSystem) ([]*xo.CodeSystemConcept, error) {
+	return xo.CodeSystemConceptByCodesystemoid(ctx, db, cs.Oid)
+}
+
 func (r *Repository) GetCodeSystemByValueSetConceptCsOid(ctx context.Context, vsc *xo.ValueSetConcept) (*xo.CodeSystem, error) {
 	return vsc.CodeSystem(ctx, r.database)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -38,13 +38,17 @@ func (e *DatabaseError) Error() string {
 }
 
 func (e *DatabaseError) NoRows(w http.ResponseWriter, r *http.Request, err error, logger *slog.Logger) {
-	logger.Error(err.Error(), slog.String("method", r.Method), slog.String("uri", r.URL.RequestURI()))
+	LogError(w, r, err, e.Msg, logger)
 	http.Error(w, e.Msg, http.StatusBadRequest)
 }
 
 func ServerError(w http.ResponseWriter, r *http.Request, err error, logger *slog.Logger) {
-	logger.Error(err.Error(), slog.String("method", r.Method), slog.String("uri", r.URL.RequestURI()))
+	LogError(w, r, err, "Server Error", logger)
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+func LogError(w http.ResponseWriter, r *http.Request, err error, errrorText string, logger *slog.Logger) {
+	logger.Error(err.Error(), slog.String("method", r.Method), slog.String("uri", r.URL.RequestURI()))
 }
 
 // func (app *Application) clientError(w http.ResponseWriter, status int) {

--- a/internal/ui/assets/css/styles.css
+++ b/internal/ui/assets/css/styles.css
@@ -205,6 +205,11 @@ footer .row {
   display: inline;
 }
 
+.cdc-footer__body-logo {
+  display: flex;
+  align-items: center;
+}
+
 .site-footer {
   padding: 2rem 0;
 }

--- a/internal/ui/assets/css/styles.css
+++ b/internal/ui/assets/css/styles.css
@@ -298,6 +298,12 @@ footer .row {
   line-height: 24px;
 }
 
+.usa-form {
+  display: inline-flex;
+  max-width: 100%;
+  width: 100%;
+}
+
 .search-results__table {
   border-radius: 6px;
   border: 1px solid rgba(0, 0, 0, 0.1);

--- a/internal/ui/assets/css/styles.css
+++ b/internal/ui/assets/css/styles.css
@@ -346,6 +346,11 @@ footer .row {
 .search-results__table .content-row {
   display: flex;
   align-items: center;
+  word-wrap: break-word;
+}
+
+.search-results__table div.col:not(.check) {
+  overflow: auto;
 }
 
 .content-row.alternate-bg {
@@ -353,6 +358,7 @@ footer .row {
 }
 .search-results__table .check {
   flex-grow: 0;
+  padding-right: 0.5rem;
 }
 
 .search-results__table .row p {

--- a/internal/ui/assets/css/styles.css
+++ b/internal/ui/assets/css/styles.css
@@ -391,10 +391,6 @@ footer .row {
   padding: 1rem 0.5rem 1rem 0rem;
 }
 
-.pagination .page-buttons {
-  padding-left: 1rem;
-}
-
 .page-buttons button {
   padding: 0.25rem 0.75rem;
   border: 1px solid lightgrey;
@@ -431,7 +427,18 @@ footer .row {
   position: absolute;
 }
 
-.download-button button {
+.download-button button:disabled {
+  border: none;
+  padding: 0.5rem 1rem 0.5rem 0.75rem;
+  border-radius: 6px;
+
+  color: #454545;
+  background-color: #c9c9c9;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+.download-button button:not(:disabled) {
   border: none;
   background-color: #005ea2;
   padding: 0.5rem 1rem 0.5rem 0.75rem;
@@ -439,7 +446,7 @@ footer .row {
   border-radius: 6px;
 }
 
-.download-button button:hover {
+.download-button button:not(:disabled):hover {
   background-color: #0b4778;
   color: white;
 }

--- a/internal/ui/components/base.templ
+++ b/internal/ui/components/base.templ
@@ -17,13 +17,10 @@ templ Base(currentPage string) {
 			<script src="/assets/js/htmx.min.js"></script>
 			<script src="/assets/js/uswds-init.min.js"></script>
 		</head>
-		<body>
+		<body id="main-body">
 			@UsaBanner("close")
 			@NavBar(currentPage)
-			<main 
-				id="main-content"
-				class="cdc-page-offset"
-			>
+			<main class="cdc-page-offset">
 				{ children... }
 			</main>
 			@Footer()

--- a/internal/ui/components/base.templ
+++ b/internal/ui/components/base.templ
@@ -20,7 +20,10 @@ templ Base(currentPage string) {
 		<body>
 			@UsaBanner("close")
 			@NavBar(currentPage)
-			<main class="cdc-page-offset">
+			<main 
+				id="main-content"
+				class="cdc-page-offset"
+			>
 				{ children... }
 			</main>
 			@Footer()

--- a/internal/ui/components/code_system_result.templ
+++ b/internal/ui/components/code_system_result.templ
@@ -34,7 +34,9 @@ templ CodeSystemResult(searchTerm string, searchResults *models.CodeSystemResult
                @CodeSystemTableHeader()
             </div>
             <div role="rowgroup">
-                @CodeSystemResultRow(true, searchResults.CodeSystems[0])
+                for _, item := range searchResults.CodeSystems {
+                    @CodeSystemResultRow(true, item)
+                }
             </div>
         </div>
     </div>

--- a/internal/ui/components/code_system_result.templ
+++ b/internal/ui/components/code_system_result.templ
@@ -1,0 +1,41 @@
+package components
+
+import (
+"github.com/skylight-hq/phinvads-go/internal/database/models"
+
+)
+
+templ CodeSystemResult(searchTerm string, searchResults *models.CodeSystemResultRow) {
+    <div>
+       @CodeSystemResultsCount(searchResults)
+        <div class="search-results__table" role="table" aria-label="table">
+            <div role="rowgroup">
+                <div class="cdc-header top-header">
+                    <div class="pagination">
+                        <div class="col search-results page-count">Showing 1 of {searchResults.CodeSystemsCount} Code Systems</div>
+                        <div class="col search-results page-buttons">
+                            <button class="active page-button">1</button>
+                            <button class="page-button">2</button>
+                            <button class="page-button">3</button>
+                            <button class="page-button">4</button>
+                            <button class="page-button">5</button>
+                            <div class="button-next">
+                                <button class="page-button">Next</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col search-results download-button">
+                        <button>
+                            <img src="/assets/img/material-icons/file_download.svg">
+                            Download Value Set
+                        </button>
+                    </div>
+                </div>
+               @CodeSystemTableHeader()
+            </div>
+            <div role="rowgroup">
+                @CodeSystemResultRow(true, searchResults.CodeSystems[0])
+            </div>
+        </div>
+    </div>
+}

--- a/internal/ui/components/code_system_result.templ
+++ b/internal/ui/components/code_system_result.templ
@@ -1,8 +1,8 @@
 package components
 
 import (
-"github.com/skylight-hq/phinvads-go/internal/database/models"
-
+    "strconv"
+    "github.com/skylight-hq/phinvads-go/internal/database/models"
 )
 
 templ CodeSystemResult(searchTerm string, searchResults *models.CodeSystemResultRow) {
@@ -11,8 +11,15 @@ templ CodeSystemResult(searchTerm string, searchResults *models.CodeSystemResult
         <div class="search-results__table" role="table" aria-label="table">
             <div role="rowgroup">
                 <div class="cdc-header top-header">
-                    <div class="pagination">
-                        <div class="col search-results page-count">Showing 1 of {searchResults.CodeSystemsCount} Code Systems</div>
+                                        <div class="col search-results page-count">Showing {strconv.Itoa(searchResults.PageCount)} of {searchResults.CodeSystemsCount} Code Systems</div>
+                    <div 
+                        if searchResults.PageCount >=5 {
+                            class="pagination"
+                        } else {
+                            class="pagination"
+                            hidden
+                        }
+                    >
                         <div class="col search-results page-buttons">
                             <button class="active page-button">1</button>
                             <button class="page-button">2</button>
@@ -25,17 +32,27 @@ templ CodeSystemResult(searchTerm string, searchResults *models.CodeSystemResult
                         </div>
                     </div>
                     <div class="col search-results download-button">
-                        <button>
-                            <img src="/assets/img/material-icons/file_download.svg">
-                            Download Value Set
-                        </button>
+                        if searchResults.ValueSetsCount == "0" {
+                            <button disabled aria-disabled="true">
+                                <img src="/assets/img/material-icons/file_download_off.svg">
+                                Download Value Set
+                            </button>         
+                        } else {
+                            <button disabled aria-disabled="true">
+                                <img src="/assets/img/material-icons/file_download_off.svg">
+                                Download Value Set
+                            </button>
+                        }
                     </div>
                 </div>
                @CodeSystemTableHeader()
             </div>
             <div role="rowgroup">
-                for _, item := range searchResults.CodeSystems {
-                    @CodeSystemResultRow(true, item)
+                for idx, item := range searchResults.CodeSystems  {
+                    if idx <= 4 {
+                        // modulo check allows alternating background color
+                        @CodeSystemResultRow(idx % 2 != 0, item)
+                    }
                 }
             </div>
         </div>

--- a/internal/ui/components/code_system_result_row.templ
+++ b/internal/ui/components/code_system_result_row.templ
@@ -1,0 +1,37 @@
+package components
+
+import "github.com/skylight-hq/phinvads-go/internal/database/models/xo"
+
+templ CodeSystemResultRow(alternate bool, result *xo.CodeSystem) {
+      <div 
+        if alternate == true {
+            class="row content-row" role="row"
+        } else {
+            class="row content-row alternate-bg" role="row"
+        }
+     >
+        <div class="col check">
+            <div role="cell">
+                <input 
+                    type="checkbox" 
+                    value={result.Codesystemcode}
+                >
+            </div>
+        </div>
+        <div class="col">
+            <div role="cell">
+                <p>{result.Codesystemcode}</p>
+            </div>
+        </div>
+        <div class="col">
+            <div role="cell">
+                <p>{result.Name}</p>
+            </div>
+        </div>
+        <div class="col">
+            <div role="cell">
+                <p>{result.Oid}</p>
+            </div>
+        </div>
+    </div>
+}

--- a/internal/ui/components/code_system_table_header.templ
+++ b/internal/ui/components/code_system_table_header.templ
@@ -1,0 +1,26 @@
+package components
+
+templ CodeSystemTableHeader() {
+     <div class="row cdc-header header-row" role="row">
+                    <div class="col check">
+                        <div role="cell">
+                            <input type="checkbox">
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div role="cell">   
+                            <p>Code System Code</p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div role="cell">
+                            <p>Code System Name</p>
+                        </div>
+                    </div>
+                        <div class="col">
+                        <div role="cell">
+                            <p>Code System OID</p>
+                        </div>
+                    </div>
+                </div>
+}

--- a/internal/ui/components/error.templ
+++ b/internal/ui/components/error.templ
@@ -1,0 +1,12 @@
+package components 
+
+templ Error(currentPage, errorText string) {
+     @Base(currentPage) {
+        <h1>
+            {currentPage}
+        </h1>
+            @SearchBar()
+        <p>{errorText}</p>
+        <div><br></div>
+    }
+}

--- a/internal/ui/components/results-count.templ
+++ b/internal/ui/components/results-count.templ
@@ -5,14 +5,6 @@ import "github.com/skylight-hq/phinvads-go/internal/database/models"
 templ CodeSystemResultsCount(result *models.CodeSystemResultRow) {
     <div class="search-results__tabs">
         <div 
-            if result.ValueSetsCount == "0" {
-               class="tab-item"
-            } else {
-                class="tab-item active"
-            }
-        >
-            Value Sets ({result.ValueSetsCount})</div>
-        <div 
             if result.ValueSetsCount == "0" && result.CodeSystemsCount != "0" {
                 class="tab-item active"
             } else {
@@ -28,7 +20,16 @@ templ CodeSystemResultsCount(result *models.CodeSystemResultRow) {
             }
         >
         Code System Concepts ({result.CodeSystemConceptsCount})</div>
+        <div 
+            if result.ValueSetsCount == "0" {
+               class="tab-item"
+            } else {
+                class="tab-item active"
+            }
+        >
+        Value Sets ({result.ValueSetsCount})</div>
     </div>
+    
 }
 
 

--- a/internal/ui/components/results-count.templ
+++ b/internal/ui/components/results-count.templ
@@ -1,0 +1,34 @@
+package components
+
+import "github.com/skylight-hq/phinvads-go/internal/database/models"
+
+templ CodeSystemResultsCount(result *models.CodeSystemResultRow) {
+    <div class="search-results__tabs">
+        <div 
+            if result.ValueSetsCount == "0" {
+               class="tab-item"
+            } else {
+                class="tab-item active"
+            }
+        >
+            Value Sets ({result.ValueSetsCount})</div>
+        <div 
+            if result.ValueSetsCount == "0" && result.CodeSystemsCount != "0" {
+                class="tab-item active"
+            } else {
+                class="tab-item"
+            }
+        >
+            Code Systems ({result.CodeSystemsCount})</div>
+        <div 
+            if result.ValueSetsCount == "0" && result.CodeSystemsCount == "0" && result.CodeSystemConceptsCount != "0"{
+                class="tab-item active"
+            } else {
+                class="tab-item"
+            }
+        >
+        Code System Concepts ({result.CodeSystemConceptsCount})</div>
+    </div>
+}
+
+

--- a/internal/ui/components/search_bar.templ
+++ b/internal/ui/components/search_bar.templ
@@ -7,32 +7,41 @@ templ SearchBar() {
             <form class="usa-form">
                 <section class="grid-col-auto">
                     <select class="usa-select" name="options" id="options">
-                        <option value> All Vocabulary </option>
-                        <option value="value1">Option A</option>
-                        <option value="value2">Option B</option>
-                        <option value="value3">Option C</option>
+                        <option value="all"> All Vocabulary </option>
+                        <option value="view">Views (Msg. Guides)</option>
+                        <option value="value_set">Value Sets</option>
+                        <option value="value_set_concept">Value Set Concepts</option>
+                        <option value="code_system">Code Systems</option>
+                        <option value="code_system_concept">Code System Concepts</option>
+                        <option value="group">Groups</option>
                     </select>
                 </section>
+                <section class="grid-col-fill" aria-label="Big search component">
+                    <div class="usa-search usa-search--big" role="search">
+                        <label class="usa-sr-only" for="search-field-en-big">Search</label>
+                        <input
+                            class="usa-input"
+                            id="search-field-en-big"
+                            type="search"
+                            name="search"
+                        />
+                        <button 
+                            hx-post="/api/search"
+                            hx-target="#main-content"
+                            hx-swap="innerHTML"
+                            class="usa-button" 
+                            type="submit"
+                        >
+                        <span class="usa-search__submit-text">Search </span>
+                        <img
+                            src="/assets/img/usa-icons-bg/search--white.svg"
+                            class="usa-search__submit-icon"
+                            alt="Search"
+                        />
+                        </button>
+                    </div>
+                </section>
             </form>
-            <section class="grid-col-fill" aria-label="Big search component">
-                <form class="usa-search usa-search--big" role="search">
-                    <label class="usa-sr-only" for="search-field-en-big">Search</label>
-                    <input
-                        class="usa-input"
-                        id="search-field-en-big"
-                        type="search"
-                        name="search"
-                    />
-                    <button class="usa-button" type="submit">
-                    <span class="usa-search__submit-text">Search </span>
-                    <img
-                        src="/assets/img/usa-icons-bg/search--white.svg"
-                        class="usa-search__submit-icon"
-                        alt="Search"
-                    />
-                    </button>
-                </form>
-            </section>
         </div>
         <div class="grid-row advanced-search-link">
             <p><a href="#">Advanced Search</a></p>

--- a/internal/ui/components/search_bar.templ
+++ b/internal/ui/components/search_bar.templ
@@ -27,7 +27,7 @@ templ SearchBar() {
                         />
                         <button 
                             hx-post="/api/search"
-                            hx-target="#main-content"
+                            hx-target="#main-body"
                             hx-swap="innerHTML"
                             class="usa-button" 
                             type="submit"

--- a/internal/ui/components/search_results.templ
+++ b/internal/ui/components/search_results.templ
@@ -1,7 +1,10 @@
 package components
 
-templ SearchResults(currentPage, searchTerm string) {
-    @Base(currentPage) {
+import "github.com/skylight-hq/phinvads-go/internal/database/models"
+
+
+templ SearchResults(currentPage, searchTerm string, searchResults *models.CodeSystemResultRow) {
+    // @Base(currentPage) {
         <h1>
             Search
         </h1>
@@ -9,78 +12,7 @@ templ SearchResults(currentPage, searchTerm string) {
         <h2>
             Results: "{searchTerm}"
         </h2>
-        <div class="search-results__tabs">
-            <div class="tab-item">Views (Msg. Guides) (2)</div>
-            <div class="tab-item active">Value Sets (62)</div>
-            <div class="tab-item">Value Set Concepts (4487)</div>
-            <div class="tab-item">Code System Concepts (951)</div>
-        </div>
-        <div class="search-results__table" role="table" aria-label="table">
-            <div role="rowgroup">
-                <div class="cdc-header top-header">
-                    <div class="pagination">
-                        <div class="col search-results page-count">Showing 10 of 62 concepts</div>
-                        <div class="col search-results page-buttons">
-                            <button class="active page-button">1</button>
-                            <button class="page-button">2</button>
-                            <button class="page-button">3</button>
-                            <button class="page-button">4</button>
-                            <button class="page-button">5</button>
-                            <div class="button-next">
-                                <button class="page-button">Next</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col search-results download-button">
-                        <button>
-                            <img src="/assets/img/material-icons/file_download.svg">
-                            Download Value Set
-                        </button>
-                    </div>
-                </div>
-                <div class="row cdc-header header-row" role="row">
-                    <div class="col check">
-                        <div role="cell">
-                            <input type="checkbox">
-                        </div>
-                    </div>
-                    <div class="col">
-                        <div role="cell">   
-                            <p>Concept Code</p>
-                        </div>
-                    </div>
-                    <div class="col">
-                        <div role="cell">
-                            <p>Concept Name</p>
-                        </div>
-                    </div>
-                        <div class="col">
-                        <div role="cell">
-                            <p>Preferred Name</p>
-                        </div>
-                    </div>
-
-                    <div class="col">
-                        <div role="cell">
-                            <p>Code System</p>
-                        </div>
-                    </div>
-
-                    <div class="col">
-                        <div role="cell">
-                            <p>Value Set</p>
-                        </div>
-                    </div>
-
-                </div>
-            </div>
-            <div role="rowgroup">
-                @ResultRow("Table Cell","Table Cell","Table Cell","Table Cell","Table Cell",true)
-                @ResultRow("Table Cell","Table Cell","Table Cell","Table Cell","Table Cell",false)
-                @ResultRow("Table Cell","Table Cell","Table Cell","Table Cell","Table Cell",true)
-                @ResultRow("Table Cell","Table Cell","Table Cell","Table Cell","Table Cell",false)
-            </div>
-        </div>
+        @CodeSystemResult(searchTerm, searchResults)
         <div><br></div>
     }
-}
+// }

--- a/internal/ui/components/search_results.templ
+++ b/internal/ui/components/search_results.templ
@@ -3,16 +3,16 @@ package components
 import "github.com/skylight-hq/phinvads-go/internal/database/models"
 
 
-templ SearchResults(currentPage, searchTerm string, searchResults *models.CodeSystemResultRow) {
-    // @Base(currentPage) {
+templ SearchResults(isDirect bool, currentPage, searchTerm string, searchResults *models.CodeSystemResultRow) {
+    @Base(currentPage) {
         <h1>
             Search
         </h1>
-        @SearchBar()
+            @SearchBar()
         <h2>
             Results: "{searchTerm}"
         </h2>
-        @CodeSystemResult(searchTerm, searchResults)
+            @CodeSystemResult(searchTerm, searchResults)
         <div><br></div>
     }
-// }
+}


### PR DESCRIPTION
resolves #44 

## What this PR does:
Adds functionality to enable retrieving CodeSystem data from the database and displaying it in the UI

### Search input
- Send a POST request to submit form data from the SearchBar component
- Add a new route and handler for above request
- Adjust the HTML layout to include the data from the dropdown menu in the form

### Display search results
- When results are returned successfully, update the url to show the search type and search term (e.g. `/search?type=code_system&input=1.0.3`
- Display a basic error message if no rows are returned from the db lookup
- Dynamically show/hide/disable the pagination buttons and download button based on results returned
- Display the first five result rows in a table:
<img width="600" alt="Screenshot 2024-09-24 at 12 06 17" src="https://github.com/user-attachments/assets/bcf828ce-9c5c-44d1-82a8-b63fc1a780ba">

## What this PR does NOT do:
- Functionality is currently limited to **CodeSystem** lookup by **OID** or **partial OID**
  - Changing the dropdown menu input will not affect which db tables are queried
  - Name/text based search is not included; results are only retrieved with a CodeSystem OID
  - A partial OID can be entered and will be matched from the string start (e.g. `1.0.3` will return `1.0.3166.1` but won't return `2.1.0.3`) 
- Full pagination is not yet implemented; the first five results returned will display in the table but page buttons do not currently work
- Related data (e.g. CodeSystem Concepts and ValueSets related to a given CodeSystem) are not yet returned/displayed in the UI
